### PR TITLE
Revert "Rename mosaik to external scheduling."

### DIFF
--- a/cosima_core/mango_direct_connection/mango_communication_network.py
+++ b/cosima_core/mango_direct_connection/mango_communication_network.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
 
-from mango.container.external_coupling import ExternalSchedulingContainer
+from mango.container.mosaik import MosaikContainer
 from typing import Dict
 
 import scenario_config
@@ -23,13 +23,13 @@ class MangoCommunicationNetwork:
        and interacts with an OMNeT++ simulation.
 
        Args:
-           client_container_mapping (Dict[str, ExternalSchedulingContainer]): A mapping of client names (in OMNeT++) to
-           ExternalSchedulingContainer instances (mango).
+           client_container_mapping (Dict[str, MosaikContainer]): A mapping of client names (in OMNeT++) to
+           MosaikContainer instances (mango).
            port (int): The port to establish socket communication with OMNeT++.
 
        Attributes:
-           _client_container_mapping (Dict[str, ExternalSchedulingContainer]): A mapping of client names (in OMNeT++) to
-           ExternalSchedulingContainer instances (mango).
+           _client_container_mapping (Dict[str, MosaikContainer]): A mapping of client names (in OMNeT++) to
+           MosaikContainer instances (mango).
            _next_activities (list): List of next activity timestamps from agents in mango containers.
            _current_time (int): Current simulation time in milliseconds.
            _loop (asyncio.AbstractEventLoop): The asyncio event loop.
@@ -43,15 +43,15 @@ class MangoCommunicationNetwork:
            _number_of_messages_received (int): Count of received messages.
        """
 
-    def __init__(self, client_container_mapping: Dict[str, ExternalSchedulingContainer], port: int):
+    def __init__(self, client_container_mapping: Dict[str, MosaikContainer], port: int):
         """
             Initialize the MangoCommunicationNetwork instance.
 
             This method sets up the necessary attributes.
 
             Args:
-                client_container_mapping (Dict[str, ExternalSchedulingContainer]): A mapping of client names (in OMNeT++) to
-                ExternalSchedulingContainer instances (mango).
+                client_container_mapping (Dict[str, MosaikContainer]): A mapping of client names (in OMNeT++) to
+                MosaikContainer instances (mango).
                 port (int): The port to establish socket communication with OMNeT++.
         """
         self._client_container_mapping = client_container_mapping
@@ -164,12 +164,12 @@ class MangoCommunicationNetwork:
         """
             Process the mango outputs from a container.
 
-            This method processes the output from a ExternalSchedulingContainer, generates message
+            This method processes the output from a MosaikContainer, generates message
             dictionaries, and adds them to the message buffer.
 
             Args:
                 container_name (str): Name of the container.
-                output: Output received from the ExternalSchedulingContainer's step.
+                output: Output received from the MosaikContainer's step.
         """
         if output.next_activity is None:
             next_activity = UNTIL


### PR DESCRIPTION
Hi!

I was trying to run cosima using the provided Dockerfile, however, it was leading to this error when running `run.py`:

~~~
inet-4.2.2:~/models$ python3 run.py 
Traceback (most recent call last):
  File "run.py", line 7, in <module>
    from cosima_core.scenarios.mango import mango_cohda_scenario, mango_simple_scenario, mango_units_scenario, \
  File "/root/models/cosima_core/scenarios/mango/mango_direct_connection_scenario.py", line 6, in <module>
    from cosima_core.mango_direct_connection.mango_communication_network import MangoCommunicationNetwork
  File "/root/models/cosima_cohatre/mango_direct_connection/mango_communication_network.py", line 4, in <module>
    from mango.container.external_coupling import ExternalSchedulingContainer
ModuleNotFoundError: No module named 'mango.container.external_coupling'
~~~

That was happening because the `mango-agents` version specified on `requirements.txt` (1.0.0) doesn't contain `mango.container.external_coupling` as a module, which was introduced [in this commit](https://github.com/OFFIS-DAI/mango/commit/3e854094131643711d0429f0094ec9e472ff8de1) after renaming the former module `mango.container.mosaik`.

This means that this code expects a newer version of `mango-agents`. However, if I bump `mango-agents` to a newer version that contains `external_coupling` (i.e. >= 1.1.1), it breaks another dependency (`mango-library`) that is only compatible with `mango-agents` 1.0.0. Then, this is not a solution :-(.

After running `git bisect` I found the code that introduced the changes that make this code incompatible with `mango-agents` 1.0.0. It was introduced in dcc107e3f22b0ed85a6f196da7f0b4cd447fd142 and it was only an rewriting to use `mango.container.external_coupling` instead of `mango.container.mosaik`. 

Then, I could fix by only reverting that commit. This PR contains only that revert commit.