### PR TITLE
Add -j flag to omnet++ make on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ ENV PATH $PATH:/usr/omnetpp/omnetpp-5.6.2/bin
 # Configure and compile
 RUN cd omnetpp-5.6.2 && \
     xvfb-run ./configure PREFER_CLANG=yes CXXFLAGS=-std=c++14 && \
-    make
+    make -j$(grep -c proc /proc/cpuinfo)
 
 # Cleanup
 RUN apt-get clean && \


### PR DESCRIPTION
Hi!

I was building Cosima using the Dockerfile, but it took too much time building OMNeT++.

This PR adds a `-j` flag for using multiple jobs to build OMNeT++, speeding up the building as many times as the number of the available CPU cores.