### PR TITLE
Add support for mosaik time resolutions different from 1 ms

### DIFF
--- a/cosima_core/mango_direct_connection/mango_communication_network.py
+++ b/cosima_core/mango_direct_connection/mango_communication_network.py
@@ -81,7 +81,7 @@ class MangoCommunicationNetwork:
             'msg_id': 'InitialMessage',
             'max_advance': UNTIL,
             'until': UNTIL,
-            'stepSize': 1000,
+            'timeResolution': 0.001,
             'logging_level': logging_level,
             'max_byte_size_per_msg_group': MAX_BYTE_SIZE_PER_MSG_GROUP
         }

--- a/cosima_core/messages/message.proto
+++ b/cosima_core/messages/message.proto
@@ -4,7 +4,7 @@ message InitialMessage {
     string msg_id = 1;
     int32 max_advance = 2;
     int32 until = 3;
-    int32 step_size = 4;
+    double time_resolution = 4;
     string logging_level = 5;
     int32 max_byte_size_per_msg_group = 6;
   }

--- a/cosima_core/messages/message_pb2.py
+++ b/cosima_core/messages/message_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\"cosima_core/messages/message.proto\"\x93\x01\n\x0eInitialMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x13\n\x0bmax_advance\x18\x02 \x01(\x05\x12\r\n\x05until\x18\x03 \x01(\x05\x12\x11\n\tstep_size\x18\x04 \x01(\x05\x12\x15\n\rlogging_level\x18\x05 \x01(\t\x12#\n\x1bmax_byte_size_per_msg_group\x18\x06 \x01(\x05\"\xb2\x01\n\x0bInfoMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x13\n\x0bmax_advance\x18\x02 \x01(\x05\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x0e\n\x06sender\x18\x04 \x01(\t\x12\x10\n\x08receiver\x18\x05 \x01(\t\x12\x0c\n\x04size\x18\x06 \x01(\x05\x12\x0f\n\x07\x63ontent\x18\x07 \x01(\t\x12\x15\n\rcreation_time\x18\x08 \x01(\x05\x12\x14\n\x0cis_falsified\x18\t \x01(\x08\"\xec\x01\n\x16SynchronisationMessage\x12\x31\n\x08msg_type\x18\x01 \x01(\x0e\x32\x1f.SynchronisationMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x13\n\x0bmax_advance\x18\x04 \x01(\x05\x12\x0f\n\x07timeout\x18\x05 \x01(\x08\x12\x16\n\x0etimeout_msg_id\x18\x06 \x01(\t\"?\n\x07MsgType\x12\x0f\n\x0bMAX_ADVANCE\x10\x00\x12\x0b\n\x07WAITING\x10\x01\x12\x16\n\x12TRANSMISSION_ERROR\x10\x02\"\xd2\x01\n\x15InfrastructureMessage\x12\x30\n\x08msg_type\x18\x01 \x01(\x0e\x32\x1e.InfrastructureMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x15\n\rchange_module\x18\x04 \x01(\t\x12$\n\x1c\x63onnection_change_successful\x18\x05 \x01(\x08\"(\n\x07MsgType\x12\x0e\n\nDISCONNECT\x10\x00\x12\r\n\tRECONNECT\x10\x01\"\x9d\x01\n\x0eTrafficMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x10\n\x08sim_time\x18\x02 \x01(\x05\x12\x0e\n\x06source\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65stination\x18\x04 \x01(\t\x12\r\n\x05start\x18\x05 \x01(\x05\x12\x0c\n\x04stop\x18\x06 \x01(\x05\x12\x10\n\x08interval\x18\x07 \x01(\x05\x12\x15\n\rpacket_length\x18\x08 \x01(\x05\"\xf5\x01\n\rAttackMessage\x12(\n\x08msg_type\x18\x01 \x01(\x0e\x32\x16.AttackMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x17\n\x0f\x61ttacked_module\x18\x04 \x01(\t\x12\r\n\x05start\x18\x05 \x01(\x05\x12\x0c\n\x04stop\x18\x06 \x01(\x05\x12\x1a\n\x12\x61ttack_probability\x18\x07 \x01(\x05\"F\n\x07MsgType\x12\x0f\n\x0bPACKET_DROP\x10\x00\x12\x18\n\x14PACKET_FALSIFICATION\x10\x01\x12\x10\n\x0cPACKET_DELAY\x10\x02\"\x81\x03\n\x0e\x43osimaMsgGroup\x12)\n\x10initial_messages\x18\x01 \x03(\x0b\x32\x0f.InitialMessage\x12#\n\rinfo_messages\x18\x02 \x03(\x0b\x32\x0c.InfoMessage\x12\x39\n\x18synchronisation_messages\x18\x03 \x03(\x0b\x32\x17.SynchronisationMessage\x12\x37\n\x17infrastructure_messages\x18\x04 \x03(\x0b\x32\x16.InfrastructureMessage\x12)\n\x10traffic_messages\x18\x05 \x03(\x0b\x32\x0f.TrafficMessage\x12\'\n\x0f\x61ttack_messages\x18\x06 \x03(\x0b\x32\x0e.AttackMessage\x12\x19\n\x11\x63urrent_time_step\x18\x07 \x01(\x05\x12 \n\x18number_of_message_groups\x18\x08 \x01(\x05\x12\x1a\n\x12number_of_messages\x18\t \x01(\x05\x62\x06proto3')
+  serialized_pb=_b('\n\"cosima_core/messages/message.proto\"\x99\x01\n\x0eInitialMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x13\n\x0bmax_advance\x18\x02 \x01(\x05\x12\r\n\x05until\x18\x03 \x01(\x05\x12\x17\n\x0ftime_resolution\x18\x04 \x01(\x01\x12\x15\n\rlogging_level\x18\x05 \x01(\t\x12#\n\x1bmax_byte_size_per_msg_group\x18\x06 \x01(\x05\"\xb2\x01\n\x0bInfoMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x13\n\x0bmax_advance\x18\x02 \x01(\x05\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x0e\n\x06sender\x18\x04 \x01(\t\x12\x10\n\x08receiver\x18\x05 \x01(\t\x12\x0c\n\x04size\x18\x06 \x01(\x05\x12\x0f\n\x07\x63ontent\x18\x07 \x01(\t\x12\x15\n\rcreation_time\x18\x08 \x01(\x05\x12\x14\n\x0cis_falsified\x18\t \x01(\x08\"\xec\x01\n\x16SynchronisationMessage\x12\x31\n\x08msg_type\x18\x01 \x01(\x0e\x32\x1f.SynchronisationMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x13\n\x0bmax_advance\x18\x04 \x01(\x05\x12\x0f\n\x07timeout\x18\x05 \x01(\x08\x12\x16\n\x0etimeout_msg_id\x18\x06 \x01(\t\"?\n\x07MsgType\x12\x0f\n\x0bMAX_ADVANCE\x10\x00\x12\x0b\n\x07WAITING\x10\x01\x12\x16\n\x12TRANSMISSION_ERROR\x10\x02\"\xd2\x01\n\x15InfrastructureMessage\x12\x30\n\x08msg_type\x18\x01 \x01(\x0e\x32\x1e.InfrastructureMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x15\n\rchange_module\x18\x04 \x01(\t\x12$\n\x1c\x63onnection_change_successful\x18\x05 \x01(\x08\"(\n\x07MsgType\x12\x0e\n\nDISCONNECT\x10\x00\x12\r\n\tRECONNECT\x10\x01\"\x9d\x01\n\x0eTrafficMessage\x12\x0e\n\x06msg_id\x18\x01 \x01(\t\x12\x10\n\x08sim_time\x18\x02 \x01(\x05\x12\x0e\n\x06source\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65stination\x18\x04 \x01(\t\x12\r\n\x05start\x18\x05 \x01(\x05\x12\x0c\n\x04stop\x18\x06 \x01(\x05\x12\x10\n\x08interval\x18\x07 \x01(\x05\x12\x15\n\rpacket_length\x18\x08 \x01(\x05\"\xf5\x01\n\rAttackMessage\x12(\n\x08msg_type\x18\x01 \x01(\x0e\x32\x16.AttackMessage.MsgType\x12\x0e\n\x06msg_id\x18\x02 \x01(\t\x12\x10\n\x08sim_time\x18\x03 \x01(\x05\x12\x17\n\x0f\x61ttacked_module\x18\x04 \x01(\t\x12\r\n\x05start\x18\x05 \x01(\x05\x12\x0c\n\x04stop\x18\x06 \x01(\x05\x12\x1a\n\x12\x61ttack_probability\x18\x07 \x01(\x05\"F\n\x07MsgType\x12\x0f\n\x0bPACKET_DROP\x10\x00\x12\x18\n\x14PACKET_FALSIFICATION\x10\x01\x12\x10\n\x0cPACKET_DELAY\x10\x02\"\x81\x03\n\x0e\x43osimaMsgGroup\x12)\n\x10initial_messages\x18\x01 \x03(\x0b\x32\x0f.InitialMessage\x12#\n\rinfo_messages\x18\x02 \x03(\x0b\x32\x0c.InfoMessage\x12\x39\n\x18synchronisation_messages\x18\x03 \x03(\x0b\x32\x17.SynchronisationMessage\x12\x37\n\x17infrastructure_messages\x18\x04 \x03(\x0b\x32\x16.InfrastructureMessage\x12)\n\x10traffic_messages\x18\x05 \x03(\x0b\x32\x0f.TrafficMessage\x12\'\n\x0f\x61ttack_messages\x18\x06 \x03(\x0b\x32\x0e.AttackMessage\x12\x19\n\x11\x63urrent_time_step\x18\x07 \x01(\x05\x12 \n\x18number_of_message_groups\x18\x08 \x01(\x05\x12\x1a\n\x12number_of_messages\x18\t \x01(\x05\x62\x06proto3')
 )
 
 
@@ -45,8 +45,8 @@ _SYNCHRONISATIONMESSAGE_MSGTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=543,
-  serialized_end=606,
+  serialized_start=549,
+  serialized_end=612,
 )
 _sym_db.RegisterEnumDescriptor(_SYNCHRONISATIONMESSAGE_MSGTYPE)
 
@@ -67,8 +67,8 @@ _INFRASTRUCTUREMESSAGE_MSGTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=779,
-  serialized_end=819,
+  serialized_start=785,
+  serialized_end=825,
 )
 _sym_db.RegisterEnumDescriptor(_INFRASTRUCTUREMESSAGE_MSGTYPE)
 
@@ -93,8 +93,8 @@ _ATTACKMESSAGE_MSGTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1157,
-  serialized_end=1227,
+  serialized_start=1163,
+  serialized_end=1233,
 )
 _sym_db.RegisterEnumDescriptor(_ATTACKMESSAGE_MSGTYPE)
 
@@ -128,9 +128,9 @@ _INITIALMESSAGE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='step_size', full_name='InitialMessage.step_size', index=3,
-      number=4, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
+      name='time_resolution', full_name='InitialMessage.time_resolution', index=3,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -161,7 +161,7 @@ _INITIALMESSAGE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=39,
-  serialized_end=186,
+  serialized_end=192,
 )
 
 
@@ -247,8 +247,8 @@ _INFOMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=189,
-  serialized_end=367,
+  serialized_start=195,
+  serialized_end=373,
 )
 
 
@@ -314,8 +314,8 @@ _SYNCHRONISATIONMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=370,
-  serialized_end=606,
+  serialized_start=376,
+  serialized_end=612,
 )
 
 
@@ -374,8 +374,8 @@ _INFRASTRUCTUREMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=609,
-  serialized_end=819,
+  serialized_start=615,
+  serialized_end=825,
 )
 
 
@@ -454,8 +454,8 @@ _TRAFFICMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=822,
-  serialized_end=979,
+  serialized_start=828,
+  serialized_end=985,
 )
 
 
@@ -528,8 +528,8 @@ _ATTACKMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=982,
-  serialized_end=1227,
+  serialized_start=988,
+  serialized_end=1233,
 )
 
 
@@ -615,8 +615,8 @@ _COSIMAMSGGROUP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1230,
-  serialized_end=1615,
+  serialized_start=1236,
+  serialized_end=1621,
 )
 
 _SYNCHRONISATIONMESSAGE.fields_by_name['msg_type'].enum_type = _SYNCHRONISATIONMESSAGE_MSGTYPE

--- a/cosima_core/simulators/communication_simulator.py
+++ b/cosima_core/simulators/communication_simulator.py
@@ -68,7 +68,7 @@ class CommunicationSimulator(mosaik_api.Simulator):
         self._node_connections = {}
         self._models = {}
         self._model_names = []
-        self._step_size = None
+        self._time_resolution = None
         self._received_answer = True
         self._number_messages_sent = 0
         self._number_messages_received = 0
@@ -95,7 +95,7 @@ class CommunicationSimulator(mosaik_api.Simulator):
 
         self._model_names = list(sim_params['client_attribute_mapping'].keys())
 
-        self._step_size = int(1 / time_resolution)
+        self._time_resolution = time_resolution
         self._omnetpp_connection = OmnetppConnection(sim_params['port'])
         self._omnetpp_connection.start_connection()
 
@@ -246,7 +246,7 @@ class CommunicationSimulator(mosaik_api.Simulator):
             'msg_id': 'InitialMessage',
             'max_advance': max_advance,
             'until': self.mosaik.world.until,
-            'stepSize': self._step_size,
+            'timeResolution': self._time_resolution,
             'logging_level': scenario_config.LOGGING_LEVEL,
             'max_byte_size_per_msg_group': MAX_BYTE_SIZE_PER_MSG_GROUP
         }
@@ -258,7 +258,7 @@ class CommunicationSimulator(mosaik_api.Simulator):
         waiting_msg = {
             'msg_type': SynchronisationMessage.MsgType.WAITING,
             'msg_id': f'WaitingMessage_{self._waiting_msgs_counter}',
-            'sim_time': self.calculate_to_ms(sim_time, self._step_size),
+            'sim_time': sim_time,
             'max_advance': max_advance,
         }
         log(f'Send WaitingMessage_{self._waiting_msgs_counter} at time {sim_time} with max advance {max_advance}')
@@ -272,11 +272,6 @@ class CommunicationSimulator(mosaik_api.Simulator):
         # needs to be divisible by step size
         value = int(value - (value % step_size))
         return value
-
-    @staticmethod
-    def calculate_to_ms(value, step_size):
-        """calculates value to milliseconds for OMNeT++"""
-        return value * step_size
 
     @staticmethod
     def check_msgs(messages, time, until):

--- a/cosima_core/simulators/omnetpp_connection.py
+++ b/cosima_core/simulators/omnetpp_connection.py
@@ -68,13 +68,11 @@ class OmnetppConnection:
 
     def sender(self, message):
         sender_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        time.sleep(1)
         sender_socket.connect((self._servername, self.observer_port))
         sender_socket.send(message)
         sender_socket.close()
 
     def return_messages(self):
-        time.sleep(0.1)
         if not self._done_receiving:
             return []
         if self.expected_messages > len(self.stored_messages):

--- a/cosima_omnetpp_project/messages/message.pb.cc
+++ b/cosima_omnetpp_project/messages/message.pb.cc
@@ -189,7 +189,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, msg_id_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, max_advance_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, until_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, step_size_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, time_resolution_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, logging_level_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::InitialMessage, max_byte_size_per_msg_group_),
   ~0u,  // no _has_bits_
@@ -308,50 +308,50 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\"cosima_core/messages/message.proto\"\223\001\n"
+      "\n\"cosima_core/messages/message.proto\"\231\001\n"
       "\016InitialMessage\022\016\n\006msg_id\030\001 \001(\t\022\023\n\013max_a"
-      "dvance\030\002 \001(\005\022\r\n\005until\030\003 \001(\005\022\021\n\tstep_size"
-      "\030\004 \001(\005\022\025\n\rlogging_level\030\005 \001(\t\022#\n\033max_byt"
-      "e_size_per_msg_group\030\006 \001(\005\"\262\001\n\013InfoMessa"
-      "ge\022\016\n\006msg_id\030\001 \001(\t\022\023\n\013max_advance\030\002 \001(\005\022"
-      "\020\n\010sim_time\030\003 \001(\005\022\016\n\006sender\030\004 \001(\t\022\020\n\010rec"
-      "eiver\030\005 \001(\t\022\014\n\004size\030\006 \001(\005\022\017\n\007content\030\007 \001"
-      "(\t\022\025\n\rcreation_time\030\010 \001(\005\022\024\n\014is_falsifie"
-      "d\030\t \001(\010\"\354\001\n\026SynchronisationMessage\0221\n\010ms"
-      "g_type\030\001 \001(\0162\037.SynchronisationMessage.Ms"
+      "dvance\030\002 \001(\005\022\r\n\005until\030\003 \001(\005\022\027\n\017time_reso"
+      "lution\030\004 \001(\001\022\025\n\rlogging_level\030\005 \001(\t\022#\n\033m"
+      "ax_byte_size_per_msg_group\030\006 \001(\005\"\262\001\n\013Inf"
+      "oMessage\022\016\n\006msg_id\030\001 \001(\t\022\023\n\013max_advance\030"
+      "\002 \001(\005\022\020\n\010sim_time\030\003 \001(\005\022\016\n\006sender\030\004 \001(\t\022"
+      "\020\n\010receiver\030\005 \001(\t\022\014\n\004size\030\006 \001(\005\022\017\n\007conte"
+      "nt\030\007 \001(\t\022\025\n\rcreation_time\030\010 \001(\005\022\024\n\014is_fa"
+      "lsified\030\t \001(\010\"\354\001\n\026SynchronisationMessage"
+      "\0221\n\010msg_type\030\001 \001(\0162\037.SynchronisationMess"
+      "age.MsgType\022\016\n\006msg_id\030\002 \001(\t\022\020\n\010sim_time\030"
+      "\003 \001(\005\022\023\n\013max_advance\030\004 \001(\005\022\017\n\007timeout\030\005 "
+      "\001(\010\022\026\n\016timeout_msg_id\030\006 \001(\t\"\?\n\007MsgType\022\017"
+      "\n\013MAX_ADVANCE\020\000\022\013\n\007WAITING\020\001\022\026\n\022TRANSMIS"
+      "SION_ERROR\020\002\"\322\001\n\025InfrastructureMessage\0220"
+      "\n\010msg_type\030\001 \001(\0162\036.InfrastructureMessage"
+      ".MsgType\022\016\n\006msg_id\030\002 \001(\t\022\020\n\010sim_time\030\003 \001"
+      "(\005\022\025\n\rchange_module\030\004 \001(\t\022$\n\034connection_"
+      "change_successful\030\005 \001(\010\"(\n\007MsgType\022\016\n\nDI"
+      "SCONNECT\020\000\022\r\n\tRECONNECT\020\001\"\235\001\n\016TrafficMes"
+      "sage\022\016\n\006msg_id\030\001 \001(\t\022\020\n\010sim_time\030\002 \001(\005\022\016"
+      "\n\006source\030\003 \001(\t\022\023\n\013destination\030\004 \001(\t\022\r\n\005s"
+      "tart\030\005 \001(\005\022\014\n\004stop\030\006 \001(\005\022\020\n\010interval\030\007 \001"
+      "(\005\022\025\n\rpacket_length\030\010 \001(\005\"\365\001\n\rAttackMess"
+      "age\022(\n\010msg_type\030\001 \001(\0162\026.AttackMessage.Ms"
       "gType\022\016\n\006msg_id\030\002 \001(\t\022\020\n\010sim_time\030\003 \001(\005\022"
-      "\023\n\013max_advance\030\004 \001(\005\022\017\n\007timeout\030\005 \001(\010\022\026\n"
-      "\016timeout_msg_id\030\006 \001(\t\"\?\n\007MsgType\022\017\n\013MAX_"
-      "ADVANCE\020\000\022\013\n\007WAITING\020\001\022\026\n\022TRANSMISSION_E"
-      "RROR\020\002\"\322\001\n\025InfrastructureMessage\0220\n\010msg_"
-      "type\030\001 \001(\0162\036.InfrastructureMessage.MsgTy"
-      "pe\022\016\n\006msg_id\030\002 \001(\t\022\020\n\010sim_time\030\003 \001(\005\022\025\n\r"
-      "change_module\030\004 \001(\t\022$\n\034connection_change"
-      "_successful\030\005 \001(\010\"(\n\007MsgType\022\016\n\nDISCONNE"
-      "CT\020\000\022\r\n\tRECONNECT\020\001\"\235\001\n\016TrafficMessage\022\016"
-      "\n\006msg_id\030\001 \001(\t\022\020\n\010sim_time\030\002 \001(\005\022\016\n\006sour"
-      "ce\030\003 \001(\t\022\023\n\013destination\030\004 \001(\t\022\r\n\005start\030\005"
-      " \001(\005\022\014\n\004stop\030\006 \001(\005\022\020\n\010interval\030\007 \001(\005\022\025\n\r"
-      "packet_length\030\010 \001(\005\"\365\001\n\rAttackMessage\022(\n"
-      "\010msg_type\030\001 \001(\0162\026.AttackMessage.MsgType\022"
-      "\016\n\006msg_id\030\002 \001(\t\022\020\n\010sim_time\030\003 \001(\005\022\027\n\017att"
-      "acked_module\030\004 \001(\t\022\r\n\005start\030\005 \001(\005\022\014\n\004sto"
-      "p\030\006 \001(\005\022\032\n\022attack_probability\030\007 \001(\005\"F\n\007M"
-      "sgType\022\017\n\013PACKET_DROP\020\000\022\030\n\024PACKET_FALSIF"
-      "ICATION\020\001\022\020\n\014PACKET_DELAY\020\002\"\201\003\n\016CosimaMs"
-      "gGroup\022)\n\020initial_messages\030\001 \003(\0132\017.Initi"
-      "alMessage\022#\n\rinfo_messages\030\002 \003(\0132\014.InfoM"
-      "essage\0229\n\030synchronisation_messages\030\003 \003(\013"
-      "2\027.SynchronisationMessage\0227\n\027infrastruct"
-      "ure_messages\030\004 \003(\0132\026.InfrastructureMessa"
-      "ge\022)\n\020traffic_messages\030\005 \003(\0132\017.TrafficMe"
-      "ssage\022\'\n\017attack_messages\030\006 \003(\0132\016.AttackM"
-      "essage\022\031\n\021current_time_step\030\007 \001(\005\022 \n\030num"
-      "ber_of_message_groups\030\010 \001(\005\022\032\n\022number_of"
-      "_messages\030\t \001(\005b\006proto3"
+      "\027\n\017attacked_module\030\004 \001(\t\022\r\n\005start\030\005 \001(\005\022"
+      "\014\n\004stop\030\006 \001(\005\022\032\n\022attack_probability\030\007 \001("
+      "\005\"F\n\007MsgType\022\017\n\013PACKET_DROP\020\000\022\030\n\024PACKET_"
+      "FALSIFICATION\020\001\022\020\n\014PACKET_DELAY\020\002\"\201\003\n\016Co"
+      "simaMsgGroup\022)\n\020initial_messages\030\001 \003(\0132\017"
+      ".InitialMessage\022#\n\rinfo_messages\030\002 \003(\0132\014"
+      ".InfoMessage\0229\n\030synchronisation_messages"
+      "\030\003 \003(\0132\027.SynchronisationMessage\0227\n\027infra"
+      "structure_messages\030\004 \003(\0132\026.Infrastructur"
+      "eMessage\022)\n\020traffic_messages\030\005 \003(\0132\017.Tra"
+      "fficMessage\022\'\n\017attack_messages\030\006 \003(\0132\016.A"
+      "ttackMessage\022\031\n\021current_time_step\030\007 \001(\005\022"
+      " \n\030number_of_message_groups\030\010 \001(\005\022\032\n\022num"
+      "ber_of_messages\030\t \001(\005b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 1623);
+      descriptor, 1629);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cosima_core/messages/message.proto", &protobuf_RegisterTypes);
 }
@@ -443,7 +443,7 @@ void InitialMessage::InitAsDefaultInstance() {
 const int InitialMessage::kMsgIdFieldNumber;
 const int InitialMessage::kMaxAdvanceFieldNumber;
 const int InitialMessage::kUntilFieldNumber;
-const int InitialMessage::kStepSizeFieldNumber;
+const int InitialMessage::kTimeResolutionFieldNumber;
 const int InitialMessage::kLoggingLevelFieldNumber;
 const int InitialMessage::kMaxByteSizePerMsgGroupFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
@@ -573,14 +573,14 @@ bool InitialMessage::MergePartialFromCodedStream(
         break;
       }
 
-      // int32 step_size = 4;
+      // double time_resolution = 4;
       case 4: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(32u /* 32 & 0xFF */)) {
+            static_cast< ::google::protobuf::uint8>(33u /* 33 & 0xFF */)) {
 
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, &step_size_)));
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &time_resolution_)));
         } else {
           goto handle_unusual;
         }
@@ -663,9 +663,9 @@ void InitialMessage::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->until(), output);
   }
 
-  // int32 step_size = 4;
-  if (this->step_size() != 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(4, this->step_size(), output);
+  // double time_resolution = 4;
+  if (this->time_resolution() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(4, this->time_resolution(), output);
   }
 
   // string logging_level = 5;
@@ -718,9 +718,9 @@ void InitialMessage::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->until(), target);
   }
 
-  // int32 step_size = 4;
-  if (this->step_size() != 0) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(4, this->step_size(), target);
+  // double time_resolution = 4;
+  if (this->time_resolution() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(4, this->time_resolution(), target);
   }
 
   // string logging_level = 5;
@@ -784,11 +784,9 @@ size_t InitialMessage::ByteSizeLong() const {
         this->until());
   }
 
-  // int32 step_size = 4;
-  if (this->step_size() != 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::Int32Size(
-        this->step_size());
+  // double time_resolution = 4;
+  if (this->time_resolution() != 0) {
+    total_size += 1 + 8;
   }
 
   // int32 max_byte_size_per_msg_group = 6;
@@ -839,8 +837,8 @@ void InitialMessage::MergeFrom(const InitialMessage& from) {
   if (from.until() != 0) {
     set_until(from.until());
   }
-  if (from.step_size() != 0) {
-    set_step_size(from.step_size());
+  if (from.time_resolution() != 0) {
+    set_time_resolution(from.time_resolution());
   }
   if (from.max_byte_size_per_msg_group() != 0) {
     set_max_byte_size_per_msg_group(from.max_byte_size_per_msg_group());
@@ -877,7 +875,7 @@ void InitialMessage::InternalSwap(InitialMessage* other) {
     GetArenaNoVirtual());
   swap(max_advance_, other->max_advance_);
   swap(until_, other->until_);
-  swap(step_size_, other->step_size_);
+  swap(time_resolution_, other->time_resolution_);
   swap(max_byte_size_per_msg_group_, other->max_byte_size_per_msg_group_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }

--- a/cosima_omnetpp_project/messages/message.pb.h
+++ b/cosima_omnetpp_project/messages/message.pb.h
@@ -273,11 +273,11 @@ class InitialMessage : public ::google::protobuf::Message /* @@protoc_insertion_
   ::google::protobuf::int32 until() const;
   void set_until(::google::protobuf::int32 value);
 
-  // int32 step_size = 4;
-  void clear_step_size();
-  static const int kStepSizeFieldNumber = 4;
-  ::google::protobuf::int32 step_size() const;
-  void set_step_size(::google::protobuf::int32 value);
+  // double time_resolution = 4;
+  void clear_time_resolution();
+  static const int kTimeResolutionFieldNumber = 4;
+  double time_resolution() const;
+  void set_time_resolution(double value);
 
   // int32 max_byte_size_per_msg_group = 6;
   void clear_max_byte_size_per_msg_group();
@@ -293,7 +293,7 @@ class InitialMessage : public ::google::protobuf::Message /* @@protoc_insertion_
   ::google::protobuf::internal::ArenaStringPtr logging_level_;
   ::google::protobuf::int32 max_advance_;
   ::google::protobuf::int32 until_;
-  ::google::protobuf::int32 step_size_;
+  double time_resolution_;
   ::google::protobuf::int32 max_byte_size_per_msg_group_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_cosima_5fcore_2fmessages_2fmessage_2eproto::TableStruct;
@@ -1496,18 +1496,18 @@ inline void InitialMessage::set_until(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:InitialMessage.until)
 }
 
-// int32 step_size = 4;
-inline void InitialMessage::clear_step_size() {
-  step_size_ = 0;
+// double time_resolution = 4;
+inline void InitialMessage::clear_time_resolution() {
+  time_resolution_ = 0;
 }
-inline ::google::protobuf::int32 InitialMessage::step_size() const {
-  // @@protoc_insertion_point(field_get:InitialMessage.step_size)
-  return step_size_;
+inline double InitialMessage::time_resolution() const {
+  // @@protoc_insertion_point(field_get:InitialMessage.time_resolution)
+  return time_resolution_;
 }
-inline void InitialMessage::set_step_size(::google::protobuf::int32 value) {
+inline void InitialMessage::set_time_resolution(double value) {
   
-  step_size_ = value;
-  // @@protoc_insertion_point(field_set:InitialMessage.step_size)
+  time_resolution_ = value;
+  // @@protoc_insertion_point(field_set:InitialMessage.time_resolution)
 }
 
 // string logging_level = 5;

--- a/docs/source/MessageTypes.md
+++ b/docs/source/MessageTypes.md
@@ -15,7 +15,7 @@ There are different types of protobuf messages with different values:
   * `max_advance` : the current value of the mosaik-internal max advance value
   * `int32 until` : the time of the simulation end in mosaik
   * `bool is_time_based`: indicates whether the simulation in mosaik is time-based or not
-  * `int32 step_size` : the step size used in the simulation, based on the step-size definition in mosaik (e.g., 1 mosaik step is equivalent to 1 millisecond)
+  * `double time_resolution` : the duration in seconds of each simulation step in mosaik, based on the time resolution definition in mosaik (e.g., 1 mosaik step is equivalent to 1 millisecond)
 * `InfoMessage`
   * `string msg_id` : a msg id identifies the message
   * `max_advance` : the current value of the mosaik-internal max advance value


### PR DESCRIPTION
Hello,
I noticed that setting a `time_resolution` for the mosaik World different from 0.001 (1 ms) does not affect the time step at which the messages are received. This effectively means that, for example, by setting a time resolution to 0.0001 (0.1 ms), messages are received in a tenth of the simulated time compared to setting the time resolution to 0.001.

Looking into the code I discovered that the C++ side of cosima assumes that each simulation step of mosaik corresponds to 1ms (i.e. 0.001 time resolution), but the duration of simulated time each time step of mosaik corresponds to can be set to any value with the `time_resolution` World parameter. In this pull request I generalized the logic converting from mosaik time steps to simulation time in such a way to account for the time resolution. The time resolution is now passed to the CosimaScheduler in the initial message. Additionally, in the protobuf definition of the messages, I have replaced the `stepSize` field with a field of type `double` for the time resolution since the `stepSize` field was not actually used in the C++ side. I avoided the name `stepSize` to prevent confusion since `stepSize` has a different meaning in mosaik.